### PR TITLE
fix node_modules path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "easy-emebddings",
+  "name": "easy-embeddings",
   "type": "module",
   "version": "1.0.0",
   "description": "Easy, fast and WASM/WebGPU accelerated vector embedding for the web platform. Locally via ONNX/Transformers.js and via API. Compatible with Browsers, Workers, Web Extensions, Node.js & co.",

--- a/scripts/setup-transformers.ts
+++ b/scripts/setup-transformers.ts
@@ -117,8 +117,16 @@ writeFileSync('transformers.js/dist/transformers.js', transformersJs)
 
 console.log("Copying transformers.js to node_modules...")
 // re-construct phantom dependency in node_modules
-rmSync('node_modules/@xenova/transformers.js', { recursive: true });
-mkdirSync('node_modules/@xenova/transformers.js', { recursive: true });
+if (existsSync("./node_modules/@xenova/transformers.js")) {
+  rmSync("./node_modules/@xenova/transformers.js", { recursive: true });
+} else {
+  if (fs.readdirSync("node_modules").length === 0) {
+    throw Error(
+      "node_modules is empty. Make sure you've installed project dependencies."
+    );
+  }
+}
+mkdirSync("node_modules/@xenova/transformers.js", { recursive: true });
 
 spawnSync('cp', ['-R', 'transformers.js', 'node_modules/@xenova/'], {
   stdio: 'inherit',


### PR DESCRIPTION
Fix typo and `node_modules` path. For whatever reason, this worked for me, not exactly sure why! 

This passes everything for me in vitest, too.
<img width="658" alt="Screenshot 2024-08-09 at 11 56 22 AM" src="https://github.com/user-attachments/assets/105ae669-c7cc-4e1d-a0d9-bc28b10ec4e7">
